### PR TITLE
Add month/year dropdown navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,16 @@
                 </button>
 
             </nav>
+            <div class="month-year-dropdown-panel" aria-label="Jump to month and year">
+                <label class="sr-only" for="month-select">Select month</label>
+                <select id="month-select" class="month-select">
+
+                </select>
+
+                <label class="sr-only" for="year-select">Select year</label>
+                <select id="year-select" class="year-select">
+                </select>
+            </div>
 
         </header>
 

--- a/styles.css
+++ b/styles.css
@@ -114,3 +114,39 @@ body {
   text-align: left;
   width: 100%;
 }
+
+.month-year-dropdown-panel {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.month-select,
+.year-select {
+  background-color: #374151;
+  color: white;
+  border: none;
+  border-radius: 10px;
+  padding: 0.5rem 0.8rem;
+  font-size: 1rem;
+}
+
+.month-select:focus,
+.year-select:focus {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
+
+/* Screen reader only utility */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/web.mjs
+++ b/web.mjs
@@ -9,6 +9,8 @@ function createMonthDaysUi() {
   const prevBtn = document.getElementById("prev-month");
   const nextBtn = document.getElementById("next-month");
   const monthBtn = document.getElementById("current-month");
+  const monthSelect = document.getElementById("month-select");
+  const yearSelect = document.getElementById("year-select");
 
   function buildEventsByDay(year, monthIndex) {
     // Convert monthIndex (0-11) to the same month name format used in days.json, e.g. "October"
@@ -41,12 +43,57 @@ function createMonthDaysUi() {
     return eventsByDay;
   }
 
+  function populateDropdowns(date) {
+    const currentMonth = date.getMonth();
+    const currentYear = date.getFullYear();
+
+    // Populate months only once
+    if (monthSelect.options.length === 0) {
+      const monthNames = [
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+      ];
+
+      monthNames.forEach((name, index) => {
+        const option = document.createElement("option");
+        option.value = index;
+        option.textContent = name;
+        monthSelect.appendChild(option);
+      });
+    }
+
+    // Populate years only once
+    if (yearSelect.options.length === 0) {
+      for (let year = 1900; year <= 2100; year++) {
+        const option = document.createElement("option");
+        option.value = year;
+        option.textContent = year;
+        yearSelect.appendChild(option);
+      }
+    }
+
+    // Sync dropdown selection with calendar
+    monthSelect.value = currentMonth;
+    yearSelect.value = currentYear;
+  }
+
   // Initial render immediately
   renderCalendar(currentDate);
 
   function renderCalendar(date) {
     clearCalendar();
     updateMonthLabel(date);
+    populateDropdowns(date);
     generateDays(date);
   }
 

--- a/web.mjs
+++ b/web.mjs
@@ -202,5 +202,23 @@ function createMonthDaysUi() {
     );
     renderCalendar(currentDate);
   });
+
+  monthSelect.addEventListener("change", () => {
+    currentDate = new Date(
+      Number(yearSelect.value),
+      Number(monthSelect.value),
+      1,
+    );
+    renderCalendar(currentDate);
+  });
+
+  yearSelect.addEventListener("change", () => {
+    currentDate = new Date(
+      Number(yearSelect.value),
+      Number(monthSelect.value),
+      1,
+    );
+    renderCalendar(currentDate);
+  });
 }
 createMonthDaysUi();


### PR DESCRIPTION
This PR improves calendar navigation and commemorative day presentation.

Changes include:

Added month/year dropdown panel for direct calendar navigation

Synced dropdowns with arrow navigation and current calendar state